### PR TITLE
Fix unhandled excetion in post10.7 from undefined workspace root

### DIFF
--- a/post10.7.js
+++ b/post10.7.js
@@ -3,6 +3,8 @@ const vscode = require('vscode');
 const GitHubIssue = require('gitHubIssue');
 
 function activate(context) {
+	if (!vscode.workspace.rootPath) return;
+    
 	const ghi = new GitHubIssue(vscode, context, true);
 	const docProvider = {
 		provideTextDocumentContent: () => ghi.createHTML()


### PR DESCRIPTION
Post v0.10.7 version does not contain check of undefined workspace root which exists in pre0.10.7 causing a uncaught exception to be thrown. This does not necessarily affect the user but does cause irritation for other developers building extensions.
